### PR TITLE
Changed "a" to "an" in extension description

### DIFF
--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Gradescope Add to Calendar",
     "version": "0.0.5",
-    "description": "Adds a add to calendar button to all student assignments on Gradescope.",
+    "description": "Adds an add to calendar button to all student assignments on Gradescope.",
     "icons": {
         "16": "assets/icons/16x16.png",
         "32": "assets/icons/32x32.png",

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "Gradescope Add to Calendar",
     "version": "0.0.5",
-    "description": "Adds a add to calendar button to all student assignments on Gradescope.",
+    "description": "Adds an add to calendar button to all student assignments on Gradescope.",
     "icons": {
         "16": "assets/icons/16x16.png",
         "32": "assets/icons/32x32.png",


### PR DESCRIPTION
In `manifest.json`, changed "a" to "an" in description field 👍